### PR TITLE
Add venue info with image, codeofconduct, and about

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,7 +14,10 @@ require 'yaml'
 # Page options, layouts, aliases and proxies
 ###
 
+page 'about.html'
 page 'sponsorship.html'
+page 'venue.html'
+page 'codeofconduct.html'
 # Per-page layout changes:
 #
 # With no layout

--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -1,0 +1,17 @@
+---
+title: About | Erie Day of Code
+---
+
+.about
+  %h1 About Erie Day of Code
+  %p.description
+    %p
+      %strong Come join us for the first Erie Day of Code event!
+    %p
+      Erie Day of Code is a one-day event taking place on Saturday, April 25th from 9am - 4pm for web developers, computer scientists, and overall tech enthusiasts! Through a series of talks, workshops, and open discussions we intend to teach and learn about the progression of web development not only in Erie, but globally.
+    %p
+      Our main goal is to build an army of geeks to take over the world! Just kidding! Though, that does sound fun...anyways! Our main goals are to build awareness about the development scene in Erie and build a strong community of web enthusiasts. The only way to do that is to hear and learn from you!
+    %p
+      Come join us on Saturday, April 25th from 9am - 4pm and see what Erie Day of Code is all about!
+    %p
+      We really hope to see you!

--- a/source/codeofconduct.html.haml
+++ b/source/codeofconduct.html.haml
@@ -1,0 +1,32 @@
+---
+title: Code of Conduct | Erie Day of Code
+---
+
+.codeofconduct
+  %h1 Code of Conduct
+  %p.description
+    %h2
+      CONDUCT POLICY
+    %p
+      Erie Day of Code is dedicated to providing a harassment-free conference experience for everyone, regardless of age, gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
+    %p
+      Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+    %p
+      Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+    %h2
+      MISCONDUCT PROCEDURES
+    %p
+      If a participant engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+    %p
+      If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+    %p
+      Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+    %p
+      We expect participants to follow these rules at all conference venues and conference-related social events.
+    %h2 CONTACTS
+    %h3 Organizers:
+    #{mail_to("sponsorship@eriedayofcode.com")}
+    %h3 Local law enforcement:
+    To contact City of Erie Police, Fire Department, or in case of emergency, dial 911
+    %h3 Local Taxi company:
+    Erie Yellow Cab - (814) 455-4441

--- a/source/venue.html.haml
+++ b/source/venue.html.haml
@@ -1,0 +1,22 @@
+---
+title: The Brewerie at Union Station | Erie Day of Code
+---
+
+.venue-info
+  %h1.venue The Brewerie at Union Station
+  %p.description
+    Join us at
+    %a{:href => "http://www.brewerie.com", :target => "blank"} The Brewerie
+    in historic Union Station in downtown Erie!
+  %p
+    First built in 1865, Union Station was rebuilt in Art Deco style in 1927 and reopened to the public.
+    %a{:href => "http://en.wikipedia.org/wiki/Union_Station_%28Erie,_Pennsylvania%29", :target => "blank"}
+      %sup 1
+    The charming rotunda hosted the Union News stand, and many merchants including a soda fountain and barbershop.
+    %a{:href => "http://www.brewerie.com/history.html", :target => "blank"}
+      %sup 2
+    The Brewerie currently resides in the old rotunda, serving up craft beer, delicious food, and a charming atmosphere.
+  %p
+    With it's central location, charming atmosphere, and rich history, we can't imagine a better place to host Erie Day of Code!
+  .image
+    %img{:alt => "The Brewerie", :height => "100%", :src => "images/TheBrewerie.jpg", :width => "100%"}/


### PR DESCRIPTION
Added venue information with the one picture, codeofconduct content, and the about page.

One thing I can't quite get right is the subscript on the citations on the venue info, they've got a leading space that shoudn't be there and a trailing space that's part of the link that shouldn't be there. If anyone knows how to fix that all quick like, awesome, otherwise I'll have to try investigate later.
